### PR TITLE
Upgrade dependencies, bump CI matrix to Java 21, fix qulice 0.27.6 violations

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 name: mvn
-on:
+'on':
   push:
     branches:
       - master
@@ -16,14 +16,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.39.0</version>
+    <version>1.44.0</version>
   </parent>
   <artifactId>jcabi-maven-slf4j</artifactId>
   <version>1.0-SNAPSHOT</version>
@@ -37,17 +37,17 @@
       -->
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.0-beta1</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.30</version>
+      <version>1.18.46</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.9.5</version>
+      <version>3.9.15</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -65,25 +65,25 @@
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
-      <version>0.9.0.M2</version>
+      <version>1.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.9.3</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.3</version>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>2.2</version>
+      <version>3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -95,7 +95,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>findbugs:.*</exclude>

--- a/src/main/java/com/jcabi/slf4j/JcabiLoggers.java
+++ b/src/main/java/com/jcabi/slf4j/JcabiLoggers.java
@@ -4,6 +4,8 @@
  */
 package com.jcabi.slf4j;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.maven.plugin.logging.Log;
@@ -25,9 +27,13 @@ import org.slf4j.Logger;
 public final class JcabiLoggers implements ILoggerFactory {
 
     /**
+     * Lock for protecting access to {@link #mlog}.
+     */
+    private final transient Lock lock = new ReentrantLock();
+
+    /**
      * Maven log.
      */
-    @SuppressWarnings("PMD.ProperLogger")
     private transient Log mlog = new SystemStreamLog();
 
     @Override
@@ -43,8 +49,11 @@ public final class JcabiLoggers implements ILoggerFactory {
      * @param log The log to set
      */
     public void setMavenLog(final Log log) {
-        synchronized (JcabiLoggers.class) {
+        this.lock.lock();
+        try {
             this.mlog = log;
+        } finally {
+            this.lock.unlock();
         }
     }
 
@@ -55,5 +64,4 @@ public final class JcabiLoggers implements ILoggerFactory {
     public Log getMavenLog() {
         return this.mlog;
     }
-
 }

--- a/src/main/java/com/jcabi/slf4j/MavenSlf4j.java
+++ b/src/main/java/com/jcabi/slf4j/MavenSlf4j.java
@@ -56,5 +56,4 @@ public final class MavenSlf4j implements SLF4JServiceProvider {
     public String getRequestedApiVersion() {
         return MavenSlf4j.REQUESTED_API_VERSION;
     }
-
 }

--- a/src/main/java/com/jcabi/slf4j/Slf4jAdapter.java
+++ b/src/main/java/com/jcabi/slf4j/Slf4jAdapter.java
@@ -9,7 +9,6 @@ import lombok.ToString;
 import org.apache.maven.plugin.logging.Log;
 import org.slf4j.Marker;
 import org.slf4j.event.Level;
-import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.LegacyAbstractLogger;
 import org.slf4j.helpers.MessageFormatter;
 
@@ -34,12 +33,11 @@ final class Slf4jAdapter extends LegacyAbstractLogger {
     /**
      * Serialization ID.
      */
-    public static final long serialVersionUID = 0x12C0976798AB5439L;
+    private static final long serialVersionUID = 0x12C0976798AB5439L;
 
     /**
      * The log to use.
      */
-    @SuppressWarnings("PMD.ProperLogger")
     private final transient Log mlog;
 
     /**
@@ -236,9 +234,7 @@ final class Slf4jAdapter extends LegacyAbstractLogger {
      * @return The message
      */
     private static String format(final String format, final Object arg) {
-        final FormattingTuple tuple =
-            MessageFormatter.format(format, arg);
-        return tuple.getMessage();
+        return MessageFormatter.format(format, arg).getMessage();
     }
 
     /**
@@ -250,9 +246,7 @@ final class Slf4jAdapter extends LegacyAbstractLogger {
      */
     private static String format(final String format, final Object first,
         final Object second) {
-        final FormattingTuple tuple =
-            MessageFormatter.format(format, first, second);
-        return tuple.getMessage();
+        return MessageFormatter.format(format, first, second).getMessage();
     }
 
     /**
@@ -262,9 +256,7 @@ final class Slf4jAdapter extends LegacyAbstractLogger {
      * @return The message
      */
     private static String format(final String format, final Object... array) {
-        final FormattingTuple tuple =
-            MessageFormatter.format(format, array);
-        return tuple.getMessage();
+        return MessageFormatter.format(format, array).getMessage();
     }
 
     /**
@@ -280,5 +272,4 @@ final class Slf4jAdapter extends LegacyAbstractLogger {
             msg
         );
     }
-
 }

--- a/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -9,7 +9,6 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.maven.plugin.logging.Log;
 import org.slf4j.ILoggerFactory;
-import org.slf4j.spi.LoggerFactoryBinder;
 
 /**
  * The binding of {@link ILoggerFactory} class with
@@ -37,8 +36,9 @@ import org.slf4j.spi.LoggerFactoryBinder;
  */
 @ToString
 @EqualsAndHashCode(of = "loggers")
-@SuppressWarnings("PMD.ConstructorShouldDoInitialization")
-public final class StaticLoggerBinder implements LoggerFactoryBinder {
+@SuppressWarnings({"PMD.ConstructorShouldDoInitialization", "deprecation"})
+public final class StaticLoggerBinder
+    implements org.slf4j.spi.LoggerFactoryBinder {
 
     /**
      * Declare the version of the SLF4J API this implementation is compiled
@@ -57,7 +57,6 @@ public final class StaticLoggerBinder implements LoggerFactoryBinder {
      * The {@link ILoggerFactory} instance returned by the
      * {@link #getLoggerFactory()} method should always be
      * the same object.
-     *
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
     public final transient JcabiLoggers loggers = new JcabiLoggers();
@@ -103,5 +102,4 @@ public final class StaticLoggerBinder implements LoggerFactoryBinder {
     public String getLoggerFactoryClassStr() {
         return this.loggers.getClass().getName();
     }
-
 }

--- a/src/test/java/com/jcabi/slf4j/JcabiLoggersTest.java
+++ b/src/test/java/com/jcabi/slf4j/JcabiLoggersTest.java
@@ -15,13 +15,11 @@ import org.slf4j.impl.StaticLoggerBinder;
 
 /**
  * Test case for {@link JcabiLoggers}.
- *
  * @since 0.1
  */
 final class JcabiLoggersTest {
 
     @BeforeAll
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     static void init() {
         StaticLoggerBinder.getSingleton().setMavenLog(
             new DefaultLog(
@@ -44,9 +42,12 @@ final class JcabiLoggersTest {
 
     @Test
     void worksWithoutMavenLog() {
-        new JcabiLoggers().getLogger("test").info(
-            "this message should be visible in system stream"
+        final org.slf4j.Logger logger = new JcabiLoggers().getLogger("test");
+        logger.info("this message should be visible in system stream");
+        MatcherAssert.assertThat(
+            "logger is created",
+            logger,
+            Matchers.notNullValue()
         );
     }
-
 }

--- a/src/test/java/com/jcabi/slf4j/Slf4jAdapterTest.java
+++ b/src/test/java/com/jcabi/slf4j/Slf4jAdapterTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Slf4jAdapter}.
- *
  * @since 0.1
  * @checkstyle ExecutableStatementCountCheck (500 lines)
  */
@@ -66,5 +65,4 @@ final class Slf4jAdapterTest {
         logger.error("error-test {} {}", "error-1", "error-2");
         logger.error("error-test-2 {} {}", "err-1", "err-2");
     }
-
 }

--- a/src/test/java/com/jcabi/slf4j/package-info.java
+++ b/src/test/java/com/jcabi/slf4j/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Maven Log to SLFJ bridge, tests.
- *
  * @since 0.1
  */
 package com.jcabi.slf4j;

--- a/src/test/java/org/slf4j/impl/StaticLoggerBinderTest.java
+++ b/src/test/java/org/slf4j/impl/StaticLoggerBinderTest.java
@@ -15,14 +15,12 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link StaticLoggerBinder}.
- *
  * @since 0.1
  */
 final class StaticLoggerBinderTest {
 
     @BeforeAll
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-    public static void init() {
+    static void init() {
         StaticLoggerBinder.getSingleton().setMavenLog(
             new DefaultLog(
                 new ConsoleLogger(
@@ -50,5 +48,4 @@ final class StaticLoggerBinderTest {
             Matchers.equalTo(JcabiLoggers.class.getName())
         );
     }
-
 }

--- a/src/test/java/org/slf4j/impl/package-info.java
+++ b/src/test/java/org/slf4j/impl/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Maven Log to SLFJ bridge, tests.
- *
  * @since 0.1
  */
 package org.slf4j.impl;


### PR DESCRIPTION
## Summary

This PR brings the project up to date with current jcabi dependency versions and gets the build green again on master:

- jcabi parent: `1.39.0` -> `1.44.0`
- slf4j-api: `2.0.0-beta1` (pre-release) -> `2.0.17`
- lombok: `1.18.30` -> `1.18.46`
- maven-plugin-api: `3.9.5` -> `3.9.15`
- org.eclipse.sisu.plexus: `0.9.0.M2` (pre-release) -> `1.0.0`
- junit-jupiter (api/engine): `5.9.3` -> `6.0.3`
- hamcrest-core: `2.2` -> `3.0`
- qulice-maven-plugin: `0.25.1` -> `0.27.6`

Qulice `0.27.6` is built for Java 21 (class file version 65), so the CI matrix is moved from `[11, 17]` to `[21]` (matching sibling jcabi projects like `jcabi-jdbc`, `jcabi-w3c`). The `actions/setup-java` and `actions/cache` steps are bumped to `v5` accordingly.

The new Qulice surfaces a number of Checkstyle/PMD rules; the code is cleaned up rather than excluded:

- `JcabiLoggers#setMavenLog`: replace `synchronized (Class.class) { ... }` with a `ReentrantLock` (`PMD.AvoidSynchronizedStatement`).
- `Slf4jAdapter`: drop redundant `@SuppressWarnings`, inline the `FormattingTuple tuple` locals (`PMD.UnnecessaryWarningSuppression`, `PMD.UnnecessaryLocalRule`), and make `serialVersionUID` private (`PMD.PublicMemberInNonPublicType`).
- `StaticLoggerBinder`: `org.slf4j.spi.LoggerFactoryBinder` is deprecated in SLF4J 2.x but still kept for legacy SLF4J 1.x consumers; the import is removed and the interface is referenced by its fully qualified name with a class-level `@SuppressWarnings("deprecation")` so `-Werror` does not fail the compile.
- Tests: drop redundant `@SuppressWarnings("PMD.ProhibitPublicStaticMethods")` and tighten visibility (`StaticLoggerBinderTest#init` -> package-private). Added a `Matchers.notNullValue()` assertion to `JcabiLoggersTest.worksWithoutMavenLog` (`PMD.UnitTestShouldIncludeAssert`).
- Style: drop empty Javadoc lines before `@`-clauses for single-paragraph descriptions, and drop empty lines before closing braces (`Checkstyle JavadocEmptyLineBeforeTagCheck`, `RegexpMultilineCheck`).

Result: `mvn --errors --batch-mode clean install -Pqulice` is green on Java 21 with all 5 unit tests passing.

## Test plan

- [x] `mvn --errors --batch-mode clean install -Pqulice` passes locally on Java 21
- [x] All 5 unit tests pass: `JcabiLoggersTest`, `StaticLoggerBinderTest`, `Slf4jAdapterTest`
- [ ] CI matrix (ubuntu/windows/macos x Java 21) all green